### PR TITLE
Gymnasium v1.0.0 support

### DIFF
--- a/wandb/integration/gym/__init__.py
+++ b/wandb/integration/gym/__init__.py
@@ -55,7 +55,7 @@ def monitor():
 
         gym_lib_version = parse_version(gym.__version__)
         _gym_version_lt_0_26 = gym_lib_version < parse_version("0.26.0")
-        _gymnasium_version_lt_1_0_0 = gym_lib_version < parse_version("1.0.0")
+        _gymnasium_version_lt_1_0_0 = gym_lib_version < parse_version("1.0.0a1")
 
     path = "path"  # Default path
     if gym_lib == "gymnasium" and not _gymnasium_version_lt_1_0_0:

--- a/wandb/integration/gym/__init__.py
+++ b/wandb/integration/gym/__init__.py
@@ -37,11 +37,6 @@ def monitor():
     if gym_lib is None:
         raise wandb.Error(_required_error_msg)
 
-    vcr = wandb.util.get_module(
-        f"{gym_lib}.wrappers.monitoring.video_recorder",
-        required=_required_error_msg,
-    )
-
     global _gym_version_lt_0_26
     global _gymnasium_version_lt_1_0_0
 

--- a/wandb/integration/gym/__init__.py
+++ b/wandb/integration/gym/__init__.py
@@ -57,15 +57,14 @@ def monitor():
         _gym_version_lt_0_26 = gym_lib_version < parse_version("0.26.0")
         _gymnasium_version_gt_0_29_1 = gym_lib_version > parse_version("0.29.1")
 
-
     path = "path"  # Default path
     if gym_lib == "gymnasium" and _gymnasium_version_gt_0_29_1:
         vcr_recorder_attribute = "RecordVideo"
-        RecordVideo = wandb.util.get_module(
-            f"{gym_lib}.wrappers.{vcr_recorder_attribute}",
+        wrappers = wandb.util.get_module(
+            f"{gym_lib}.wrappers",
             required=_required_error_msg,
         )
-        recorder = RecordVideo  # Use new API class
+        recorder = getattr(wrappers, vcr_recorder_attribute)
     else:
         # Breaking change in gym 0.26.0
         vcr_recorder_attribute = "ImageEncoder" if _gym_version_lt_0_26 else "VideoRecorder"


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes https://github.com/wandb/wandb/issues/7047
- Related: https://github.com/Farama-Foundation/Gymnasium/issues/944

This PR updates the `monitor_gym` integration to support the upcoming Gymnasium `v1.0.0` release. The key changes include:

- Added version checks for Gymnasium to handle breaking changes introduced in `v1.0.0`.
- Updated the handling of RecordVideo for Gymnasium `v1.0.0` and later versions.
- Adjusted the logic to maintain backward compatibility with older versions of both Gym and Gymnasium.
- Ensured that the path variable is set correctly based on the Gym/Gymnasium version.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

I ran the ["Stable Baselines 3 - Track Experiments with Weights and Biases"](https://github.com/wandb/examples/blob/master/colabs/stable_baselines3/Stable_Baselines3_wandb_experiment_tracking.ipynb) example Jupyter notebook using:
- Gymnasium pre-v1.0.0: Specifically, gymnasium==0.29.1 with stable-baselines3==2.4.0a1.
  - ✅ Result: The notebook runs successfully, and videos of the RL agent training in Gymnasium environments are uploaded to Weights and Biases and viewable in the UI.
- Gymnasium post-v1.0.0 pre-release: Specifically, gymnasium==1.0.0a2.
  - ⚠️ Result: It is not possible to pip install the stable-baselines3 dependency (specifically stable-baselines3<=2.4.0a1) since it requires gymnasium<0.30,>=0.28.1. However, one can now use monitor_gym=True in wandb.init() with post-v1.0.0 versions of Gymnasium.
  - Note: To ensure full functionality with the W&B-Gymnasium integration for post-v1.0.0 versions of Gymnasium, we will have to wait for other projects that depend on Gymnasium to support post-v1.0.0 versions. These projects are noted here: https://github.com/Farama-Foundation/Gymnasium/issues/944

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
